### PR TITLE
Fix compilation warnings on ioctl-echo-loop and Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && \
       git \
       protobuf-compiler \
       rsync \
-      rust-all \
+      rust-all=1.58.1+dfsg1~ubuntu1-0ubuntu2 \
       && \
     rm -rf /var/lib/apt/lists/*
 

--- a/linux/rollup/ioctl-echo-loop/Makefile
+++ b/linux/rollup/ioctl-echo-loop/Makefile
@@ -27,7 +27,7 @@ RVCXX = $(CROSS_COMPILE)g++
 RVCOPY = $(CROSS_COMPILE)objcopy
 RVDUMP = $(CROSS_COMPILE)objdump
 STRIP = $(CROSS_COMPILE)strip
-RISCV_CFLAGS :=-march=$(RISCV_ARCH) -mabi=$(RISCV_ABI)
+CFLAGS :=-Wall -pedantic -O2 -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI)
 
 CONTAINER_MAKE := /usr/bin/make
 CONTAINER_BASE := /opt/cartesi/tools
@@ -42,7 +42,7 @@ extra.ext2: ioctl-echo-loop
 	$(MAKE) toolchain-exec CONTAINER_COMMAND="$(CONTAINER_MAKE) $@.toolchain"
 
 ioctl-echo-loop.toolchain:
-	$(RVCC) -O2 -o ioctl-echo-loop ioctl-echo-loop.c
+	$(RVCC) $(CFLAGS) -o ioctl-echo-loop ioctl-echo-loop.c
 	$(STRIP) ioctl-echo-loop
 
 extra.ext2.toolchain:


### PR DESCRIPTION
The tools are not building as is.
check: https://discord.com/channels/600597137524391947/1107945240360394853/1177252457894641745
Use a fixed rust version as described on the thread.

There are also some compiler warning fixes on a separate commit.