### PR TITLE
fix: add stty -onlcr to cartesi-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 
 MAJOR := 0
 MINOR := 14
-PATCH := 1
+PATCH := 2
 LABEL :=
 VERSION := $(MAJOR).$(MINOR).$(PATCH)$(LABEL)
 

--- a/sys-utils/cartesi-init/cartesi-init
+++ b/sys-utils/cartesi-init/cartesi-init
@@ -1,5 +1,8 @@
 #!/bin/busybox sh
 
+# disable terminal translation from nl to cr nl
+busybox stty -onlcr
+
 # mount
 busybox mkdir -p /dev/pts /dev/shm
 busybox mount -o nosuid,nodev,noexec          -t proc proc /proc


### PR DESCRIPTION
The expected behavior of the emulator is to pass through new-line control-characters directly from the inside to the outside. On the outside, if the output of the emulator is connected to a file, there should be no addition of a carriage-return. If, however, the output is connected to a terminal, the terminal itself will have been configured to add the carriage-return on its own. 

In other words, we expect the following command to have the output shown
```
cartesi-machine.lua --no-init-splash --quiet -- echo | xxd
00000000: 0a                                       .
```

Instead, what we see before this PR (but when using a yet-to-be-released kernel linked to [opensbi-1.3.1-ctsi-2](https://github.com/cartesi/opensbi/releases/tag/v1.3.1-ctsi-2)) is

```
cartesi-machine.lua --no-init-splash --quiet -- echo | xxd
00000000: 0d0a                                     ..
```

This is because the terminal inside the emulator is configured with `onlcr`, so it is adding the carriage-return whenever it sees a new-line.

The PR configures the terminal with `-onlcr` so this doesn't happen.

Interestingly, prior to opensbi-1.3.1-ctsi-2, opensbi itself was adding yet another carriage-return on its own, whenever it saw a new-line sent to the legacy putchar we use with HTIF console. So the output was

```
cartesi-machine.lua --no-init-splash --quiet -- echo | xxd
00000000: 0d0d 0a                                  ...
```
