### PR TITLE
feat: increase rootfs tools size from 100MB to 256MB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ $(TOOLS_ROOTFS) fs: $(TOOLS_DEB)
 	  --file fs/Dockerfile \
 	  . && \
 	bsdtar -cf rootfs.gnutar --format=gnutar @rootfs.tar && \
-	xgenext2fs -fzB 4096 -b 25600 -i 4096 -a rootfs.gnutar -L rootfs $(TOOLS_ROOTFS) && \
+	xgenext2fs -fzB 4096 -b 65536 -i 4096 -a rootfs.gnutar -L rootfs $(TOOLS_ROOTFS) && \
 	rm -f rootfs.gnutar rootfs.tar
 
 env:

--- a/fs/Dockerfile
+++ b/fs/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && \
         jq=1.6-2.1ubuntu3 \
         lua5.4=5.4.4-1 \
         lua-socket=3.0~rc1+git+ac3201d-6 \
-        xxd=2:8.2.3995-1ubuntu2.15 \
+        xxd=2:8.2.3995-1ubuntu2.16 \
         file=1:5.41-3ubuntu0.1 \
         /tmp/${TOOLS_DEB} \
         && \


### PR DESCRIPTION
This fixes #32 

Currently the rootfs is too small for playing with VirtIO networking, you can't use `apt-get update && apt-get install -y python` for example because there is not enough disk space.

I believe we should make easier to let people experiment trying out packages with less friction using the rootfs we provide as example, the increase from 100MB to 256MB is enough to allow people installing and experimenting `python` and other packages.

For example, after this PR, you can execute the following without errors:
```lua
$ cartesi-machine --network --append-init=USER=root -it "apt-get update && apt-get install -y python && python"
...
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
```
