### PR TITLE
Missing mkdir in make install-mock

### DIFF
--- a/sys-utils/libcmt/Makefile
+++ b/sys-utils/libcmt/Makefile
@@ -116,6 +116,7 @@ mock: $(mock_LIB)
 install-mock: $(mock_LIB)
 	mkdir -p $(DESTDIR)$(PREFIX)/lib
 	cp -f $< $(DESTDIR)$(PREFIX)/lib
+	mkdir -p $(DESTDIR)$(PREFIX)/include/libcmt/
 	cp -f src/*.h $(DESTDIR)$(PREFIX)/include/libcmt/
 	mkdir -p $(DESTDIR)$(PREFIX)/lib/pkgconfig
 	sed -e 's|@ARG_PREFIX@|$(PREFIX)|g' src/libcmt_mock.pc > $(DESTDIR)$(PREFIX)/lib/pkgconfig/libcmt.pc


### PR DESCRIPTION
```
make install-mock PREFIX=$PWD/_install
```

fails because of missing mkdir of header files.
