### PR TITLE
Release machine-guest-tools v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.18.0] - 2026-08-03
+### Added
+- Added `memoryrange` tool, also installed as `flashdrive` and `nvram`, to look up memory ranges by label
+- Added `readmmap` and `writemmap` tools to read and write memory ranges via `mmap`
+- Added `--base64-payload` and `--utf8-payload` options to rollup tool
+- Added bundled `cmio.h`, allowing libcmt to compile without kernel headers
+- Added hex and base64 codec tests
+
 ### Changed
-- Renamed the file suffix written by the libcmt mock for the outputs Merkle root from `.outputs_root_hash` to `.outputs_merkle_root`, aligning with the terminology used in the rest of the project
+- Renamed outputs root hash to outputs Merkle root in libcmt
+- Renamed `HTIF_YIELD_REASON_ADVANCE` and `HTIF_YIELD_REASON_INSPECT` constants
+- Look up memory range labels via device tree aliases
+- Consolidated hex and base64 codecs shared by the rollup and hex tools
+- Reject unexpected extra arguments in rollup tool
+- Compile rollup and hex tools with C++23
+- Bumped nlohmann JSON to 3.12.0
+- Bumped kernel to 6.5.13-ctsi-2, which enables UIO support
+- Improved CI caching and ran the license scanner natively
+
+### Removed
+- Removed `flashdrive` script, replaced by `memoryrange` tool
+- Removed unimplemented `cmt_abi_start_frame` declaration
+
+### Fixed
+- Fixed rollup tool resetting the outputs Merkle tree on accept
+- Fixed hex tool failing on partial reads and accepting invalid hex digits
+- Fixed generation of `ffi.h`
 
 ## [0.17.2] - 2025-10-21
 ### Changed
@@ -209,7 +235,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [0.2.0]
 - [0.1.0]
 
-[Unreleased]: https://github.com/cartesi/machine-guest-tools/compare/v0.17.2...HEAD
+[Unreleased]: https://github.com/cartesi/machine-guest-tools/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/cartesi/machine-guest-tools/releases/tag/v0.18.0
 [0.17.2]: https://github.com/cartesi/machine-guest-tools/releases/tag/v0.17.2
 [0.17.1]: https://github.com/cartesi/machine-guest-tools/releases/tag/v0.17.1
 [0.17.0]: https://github.com/cartesi/machine-guest-tools/releases/tag/v0.17.0

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 MAJOR := 0
 MINOR := 18
 PATCH := 0
-LABEL := test-1
+LABEL :=
 VERSION := $(MAJOR).$(MINOR).$(PATCH)$(LABEL)
 
 TOOLS_TARGZ := machine-guest-tools_riscv64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ TOOLS_ROOTFS_TAR := rootfs-tools.tar
 TOOLS_ROOTFS_EXT2 := rootfs-tools.ext2
 TOOLS_ROOTFS_IMAGE := cartesi/rootfs-tools:$(VERSION)
 
-LINUX_IMAGE_TAG ?= v0.21.0-test1
+LINUX_IMAGE_TAG ?= v0.21.0
 LINUX_IMAGE_VERSION ?= v0.21.0
-LINUX_VERSION ?= 6.5.13-ctsi-2-uio-test1
+LINUX_VERSION ?= 6.5.13-ctsi-2
 LINUX_HEADERS_URLPATH := https://github.com/cartesi/machine-linux-image/releases/download/${LINUX_IMAGE_TAG}/linux-libc-dev-riscv64-cross-${LINUX_VERSION}-${LINUX_IMAGE_VERSION}.deb
-LINUX_HEADERS_SHA256 := 879ed9f8d88b248fde1dd4715f4060cef888720df14d829f8d64d81bdf71a35d
+LINUX_HEADERS_SHA256 := 3e10f582349fdd0877f595f00659e95c01fd0af837294f05901363927781bc65
 
 PREFIX ?= /usr
 DESTDIR ?= .


### PR DESCRIPTION
Also bump linux image to `6.5.13-ctsi-2` final tag